### PR TITLE
Implements a setMeta() method for Nodes

### DIFF
--- a/packages/naetverk/src/lib/node.ts
+++ b/packages/naetverk/src/lib/node.ts
@@ -104,6 +104,11 @@ export class Node {
     this.outputs.delete(output.key);
   }
 
+  setMeta(meta: { [key: string]: unknown }) {
+    this.meta = meta;
+    return this;
+  }
+
   getConnections() {
     const ios = [...this.inputs.values(), ...this.outputs.values()];
     return ios.reduce((arr, io) => {


### PR DESCRIPTION
Based on the  PR from @danilopolani in to the retejs repo: 

```typescript
    builder (node) {
        return node
            .setMeta({ foo: 'bar' })
            .addControl(...)
            .addInput(...)
            .addOutput(...);
    } 
```